### PR TITLE
Don't focus when calling with onInitialize

### DIFF
--- a/autogrow.js
+++ b/autogrow.js
@@ -1,4 +1,4 @@
-;(function($){    
+;(function($){
     //pass in just the context as a $(obj) or a settings JS object
     $.fn.autogrow = function(opts) {
         var that = $(this).css({overflow: 'hidden', resize: 'none'}) //prevent scrollies
@@ -18,7 +18,7 @@
             var min, clone;
             elem = $(elem);
             //if the element is "invisible", we get an incorrect height value
-            //to get correct value, clone and append to the body. 
+            //to get correct value, clone and append to the body.
             if (elem.is(':visible') || parseInt(elem.css('height'), 10) > 0) {
                 min = parseInt(elem.css('height'), 10) || elem.innerHeight();
             } else {
@@ -36,19 +36,19 @@
                 clone.remove();
             }
             if (opts.fixMinHeight) {
-                elem.data('autogrow-start-height', min); //set min height                                
+                elem.data('autogrow-start-height', min); //set min height
             }
             elem.css('height', min);
-            
+
             if (opts.onInitialize && elem.length) {
-                resize.call(elem[0]);
+                resize.call(elem[0], true);
             }
         });
         opts.context
             .on('keyup paste', selector, resize)
         ;
-    
-        function resize (e){
+
+        function resize (e, dontFocus){
             var box = $(this)
                 , oldHeight = box.innerHeight()
                 , newHeight = this.scrollHeight
@@ -69,19 +69,19 @@
                         //add clone class for extra css rules
                         .addClass(opts.cloneClass)
                         //make "invisible", remove height restriction potentially imposed by existing CSS
-                        .css({position: 'absolute', zIndex:-10, height: ''}) 
+                        .css({position: 'absolute', zIndex:-10, height: ''})
                         //populate with content for consistent measuring
-                        .val(box.val()) 
+                        .val(box.val())
                     ;
                     box.after(clone); //append as close to the box as possible for best CSS matching for clone
                     do { //reduce height until they don't match
                         newHeight = clone[0].scrollHeight - 1;
                         clone.innerHeight(newHeight);
                     } while (newHeight === clone[0].scrollHeight);
-                    newHeight++; //adding one back eliminates a wiggle on deletion 
+                    newHeight++; //adding one back eliminates a wiggle on deletion
                     clone.remove();
-                    box.focus(); // Fix issue with Chrome losing focus from the textarea.
-                    
+                    if (!!dontFocus) box.focus(); // Fix issue with Chrome losing focus from the textarea.
+
                     //if user selects all and deletes or holds down delete til beginning
                     //user could get here and shrink whole box
                     newHeight < minHeight && (newHeight = minHeight);
@@ -89,7 +89,7 @@
                 } else { //just set to the minHeight
                     box.innerHeight(minHeight);
                 }
-            } 
+            }
         }
         return that;
     }


### PR DESCRIPTION
Actually the initialize call will focus the textarea, and on smartphones it will opens the virtual keyboard, should not!
